### PR TITLE
[FIX] resolveDbRefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yeldirium/js-mongodb-utilities",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A collection of utility function for interacting with the node.js mongodb drive.",
   "keywords": [
     "mongodb"


### PR DESCRIPTION
Fixed a bug where an array would not be resolved correctly, if the elements are not DbRefs themselves, but contain properties which are DbRefs.
Also added regression tests for this bug.